### PR TITLE
Improve HTTP auth with bugzilla

### DIFF
--- a/conf/bugzilla.conf
+++ b/conf/bugzilla.conf
@@ -18,5 +18,7 @@ method = REST
 # username and password for bot account
 bugzilla_user = demo
 bugzilla_pwd = demo
+# Set to to true to use http auth with bugzilla
+use_http_auth = false
 # default comment template, cheetah
 comment_template = /srv/BOSS/templates/bugzilla-comment

--- a/modules/boss/bz/config.py
+++ b/modules/boss/bz/config.py
@@ -18,6 +18,11 @@ def parse_bz_config(config):
         bzs[bz]['server'] = config.get(bz, 'bugzilla_server')
         bzs[bz]['user'] = config.get(bz, 'bugzilla_user')
         bzs[bz]['password'] = config.get(bz, 'bugzilla_pwd')
+
+        bzs[bz]['use_http_auth'] = False
+        if config.has_option(bz, "use_http_auth"):
+            bzs[bz]['use_http_auth'] = config.getboolean(bz, "use_http_auth")
+
         template = config.get(bz, 'comment_template')
         try:
             bzs[bz]['template'] = open(template).read()

--- a/modules/boss/bz/xmlrpc.py
+++ b/modules/boss/bz/xmlrpc.py
@@ -12,11 +12,17 @@ class BugzillaXMLRPC(BaseBugzilla):
         super(BugzillaXMLRPC, self).__init__()
 
         self._server = bz_conf['server']
-        proto = urllib.splittype(self._server)[0]
         self._user = bz_conf['user']
         self._passwd = bz_conf['password']
+        transport_params = {
+            'proto':  urllib.splittype(self._server)[0]
+        }
+        if bz_conf['use_http_auth']:
+            transport_params['username'] = self._user
+            transport_params['password'] = self._passwd
+
         self._rpc = xmlrpclib.ServerProxy(self._server,
-                transport=PyCURLTransport(proto=proto))
+                transport=PyCURLTransport(**transport_params))
 
     def __xmlrpc_call(self, name, param):
         """Helper to make the xml-rpc call and handle faults."""
@@ -30,7 +36,6 @@ class BugzillaXMLRPC(BaseBugzilla):
             else:
                 msg = getattr(fault, "faultString", str(fault))
             raise BugzillaError(code, msg)
-        
 
     def login(self):
         self.__xmlrpc_call("User.login", {


### PR DESCRIPTION
Earlier HTTP auth credentials had to be included in the bugzilla URL and
in case of errors those can leak as the url is included in the error
message.