### PR TITLE
check_l10_update fixes

### DIFF
--- a/participants/check_l10n_update.py
+++ b/participants/check_l10n_update.py
@@ -161,7 +161,7 @@ class ParticipantHandler(BuildServiceParticipant):
         old_tar = os.path.join(tmp_dir_old, old_tar)
         new_tar = os.path.join(tmp_dir_new, new_tar)
         old_ts_files = _get_ts_files(_extract_tar(old_tar, old_ts_dir))
-        new_ts_files = _get_ts_files(_extract_tar(new_tar, old_ts_dir))
+        new_ts_files = _get_ts_files(_extract_tar(new_tar, new_ts_dir))
 
         old_langs = set(old_ts_files.keys())
         new_langs = set(new_ts_files.keys())

--- a/participants/check_l10n_update.py
+++ b/participants/check_l10n_update.py
@@ -104,10 +104,18 @@ class ParticipantHandler(object):
                            tmp_dir_new + "/new.rpm")
 
         # extract rpms
-        old_file = extract_rpm(tmp_dir_old + "/old.rpm", tmp_dir_old)
-        new_file = extract_rpm(tmp_dir_new + "/new.rpm", tmp_dir_new)
+        old_file = [
+            f for f in
+            extract_rpm(tmp_dir_old + "/old.rpm", tmp_dir_old)
+            if '.tar' in f
+        ]
+        new_file = [
+            f for f in
+            extract_rpm(tmp_dir_new + "/new.rpm", tmp_dir_new)
+            if '.tar' in f
+        ]
 
-        #rpm contains tar.bz2 and .spec file. Open and extract tar.bz2
+        #Open and extract the tar ball
         old_tar = tarfile.open(tmp_dir_old + '/' + old_file[0])
         old_tar.extractall(old_ts_dir)
         new_tar = tarfile.open(tmp_dir_new + '/' + new_file[0])

--- a/participants/check_l10n_update.py
+++ b/participants/check_l10n_update.py
@@ -252,6 +252,9 @@ def _extract_tar(tar_file, target_dir):
     compressed archives.
     """
     tar_file = os.path.abspath(tar_file)
+    target_dir = os.path.abspath(target_dir)
+    if not os.path.exists(target_dir):
+        os.makedirs(target_dir)
     output = check_output(
         ['tar', '-vxaf', tar_file],
         cwd=target_dir


### PR DESCRIPTION
Originally thought that it was failing because it was trying to extract something else than the tarball, but it turned out that the python tarfile module has problems with some compressed archives.

So implemented extracting the the tarball by calling tar instead.
And also cleaned up and and refactored the code in general.