### PR TITLE
Stateless spec parsing

### DIFF
--- a/modules/boss/rpm.py
+++ b/modules/boss/rpm.py
@@ -6,12 +6,17 @@ from tempfile import NamedTemporaryFile
 import rpm
 
 
-def parse_spec(spec_file):
+def parse_spec(spec_file, keep_config=False):
     """Simple wrapper around rpm.spec that catches errors printed to stdout
     :param spec_file: spec file name
+    :param keep_config: If set to True, does not call rpm.reloadConfig()
+        This can be used to preserve the internal rpm state with any custom
+        macros or definitions.
     :returns: rpm.spec object instance
     :raises: ValueError in case parsing failed
     """
+    if not keep_config:
+        rpm.reloadConfig()
 
     with NamedTemporaryFile(mode="w+") as tmplog:
         # rpm will print errors to stdout if logfile is not set

--- a/modules/boss/rpm.py
+++ b/modules/boss/rpm.py
@@ -1,8 +1,10 @@
 """RPM package handling helpers."""
 
+from __future__ import absolute_import
 from subprocess import Popen, PIPE, CalledProcessError
 from tempfile import NamedTemporaryFile
 import rpm
+
 
 def parse_spec(spec_file):
     """Simple wrapper around rpm.spec that catches errors printed to stdout
@@ -16,10 +18,12 @@ def parse_spec(spec_file):
         rpm.setLogFile(tmplog)
 
         try:
-            rpm.spec(spec_file)
+            spec = rpm.spec(spec_file)
         except ValueError as exc:
             # re-raise errors with rpm output appended to message
             raise ValueError(str(exc) + open(tmplog.name, 'r').read())
+        return spec
+
 
 def extract_rpm(rpm_file, work_dir, patterns=None):
     """Extract rpm package contents.

--- a/modules/boss/spec.py
+++ b/modules/boss/spec.py
@@ -1,23 +1,5 @@
 from __future__ import absolute_import
-from tempfile import NamedTemporaryFile
-import rpm
+import warnings
+from .rpm import parse_spec  # noqa
 
-def parse_spec(spec_file):
-    """Simple wrapper around rpm.spec that catches errors printed to stdout
-    :param spec_file: spec file name
-    :returns: rpm.spec object instance
-    :raises: ValueError in case parsing failed
-    """
-
-    with NamedTemporaryFile(mode="w+") as tmplog:
-        # rpm will print errors to stdout if logfile is not set
-        rpm.setLogFile(tmplog)
-
-        try:
-            spec = rpm.spec(spec_file)
-        except ValueError as exc:
-            # re-raise errors with rpm output appended to message
-            raise ValueError(str(exc) + open(tmplog.name, 'r').read())
-
-        return spec
-
+warnings.warn('boss.spec module is deprecated, use boss.rpm instead')

--- a/participants/check_package_is_complete.py
+++ b/participants/check_package_is_complete.py
@@ -40,7 +40,7 @@ from tempfile import NamedTemporaryFile
 
 from buildservice import BuildService
 from boss.checks import CheckActionProcessor
-from boss.spec import parse_spec
+from boss.rpm import parse_spec
 from debian.deb822 import Dsc
 
 class SourceError(Exception):

--- a/participants/check_valid_changes.py
+++ b/participants/check_valid_changes.py
@@ -51,7 +51,7 @@ from rpmUtils.miscutils import compareEVR, stringToVersion
 from tempfile import NamedTemporaryFile
 
 try:
-    from boss.spec import parse_spec
+    from boss.rpm import parse_spec
     from boss.checks import CheckActionProcessor
     from buildservice import BuildService
 except ImportError, exc:

--- a/rpm/boss-standard-workflow.spec
+++ b/rpm/boss-standard-workflow.spec
@@ -551,7 +551,7 @@ Vendor: Pami Ketolainen <ext-pami.o.ketolainen@nokia.com>
 Requires: python >= 2.5
 Requires: python-ruote-amqp
 Requires: python-buildservice
-Requires: rpm
+Requires: rpm-python >= 4.10.0
 Requires: cpio
 
 %description -n python-boss-common


### PR DESCRIPTION
By default the rpm module preserves the internal state, so calls to rpm.spec() would inherit definitions and macros and what not from the previously parsed spec files, which is not usually what we want.