### PR TITLE
[bz] Don't when a bad bug match is found during BZ updates. JB#53376

### DIFF
--- a/participants/bz.py
+++ b/participants/bz.py
@@ -215,7 +215,9 @@ def handle_mentioned_bug(bugzilla, bugnum, extra_data, wid, trigger, log):
             msg = "Bug %s not found" % bugnum
             log.info(msg)
             wid.fields.msg.append(msg)
-            wid.result = False
+            # Don't set wid.result = False as just mentioning a
+            # missing bug should not cause a fail in the overall
+            # process
             return False
         raise
 


### PR DESCRIPTION
If a changelog mentions a bug which is not found (eg a typo) then
don't fail the whole process when trying to update the bug status.

Note that check_mentions_bug does not try to check if a bug is valid.

Signed-off-by: David Greaves <david.greaves@jolla.com>